### PR TITLE
v0.4.0: Development <- Dev-LMB

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,78 @@ Chrome (Windows) or Chromium (Linux)
 ## Requirements for users
 Chrome (Windows) or Chromium (Linux)
 
+## How to use (with go get)
+first run the following in CMD (with go installed)
+<code>go get github.com/NineNineFive/go-local-web-gui/</code>
+Example: how to add framework to main.go
+<pre>
+package main
+
+import (
+	"api"
+	"fileserver"
+	"launcher"
+	"net/http"
+	"os"
+	"runtime"
+)
+
+var projectName = "NewProjectName"
+var organisationName = "NewCompanyName"
+
+// var address = "localhost:10995"
+var frontendPath = "./frontend"
+
+var chromeLauncher = launcher.ChromeLauncher{
+	Location:                "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
+	LocationCMD:             "C:\\\"Program Files\"\\Google\\Chrome\\Application\\chrome.exe",
+	FrontendInstallLocation: os.Getenv("localappdata") + "\\Google\\Chrome\\InstalledApps\\" + organisationName + "\\" + projectName,
+	Domain:                  "localhost",
+	PortMin:                 19430,
+	PreferredPort:           19451,
+	PortMax:                 19500,
+}
+
+var chromiumLauncher = launcher.ChromiumLauncher{
+	Location:      "/var/lib/snapd/desktop/applications/chromium_chromium.desktop", // TODO: check if better location or can be customised
+	Domain:        "localhost",
+	PortMin:       19430,
+	PreferredPort: 19451,
+	PortMax:       19500,
+}
+
+func main() {
+	launchApp()
+}
+
+func initHTTPHandlers() {
+	http.HandleFunc("/", fileserver.ServeFileServer)
+	http.HandleFunc("/api/", api.ServeAPIUseGZip)
+}
+
+func launchApp() {
+	switch runtime.GOOS {
+	case "windows":
+		initHTTPHandlers()
+		launcher.StartFrontendAndBackendWindows(frontendPath, chromeLauncher)
+		return
+	case "darwin": // "mac"
+		panic("Darwin Not Supported Yet")
+		return
+	case "linux": // "linux"
+		initHTTPHandlers()
+		launcher.StartFrontendAndBackendLinux(frontendPath, chromiumLauncher)
+		return
+	default: // "freebsd", "openbsd", "netbsd"
+		initHTTPHandlers()
+		launcher.StartFrontendAndBackendLinux(frontendPath, chromiumLauncher)
+		return
+	}
+}
+</pre>
+
 ## How to run
 <code>go run main.go</code>
+
+## How to build
+<code>go build -ldflags -H=windowsgui -o NewProjectName.exe</code>


### PR DESCRIPTION
Fixed Bidirectional open/close of application in issue: #5 
This is the implemented solution and rework of the application, this version can be "go get"

(this pull request did not get several commits, as they were put on LatestRelease by accident. The following changelogs should have the following)

chromeLauncher.go: Modified
* Implemented and fixed bidirectional open/close of application
* Replaced go-cmd with Exec.command
* Added comments
* Refactored
(https://github.com/NineNineFive/go-local-web-gui/commit/2c242d3271036feb72cff39e6910e5702a120a20)

cmd.go: Removed
* Replaced go-cmd with Exec.command
(https://github.com/NineNineFive/go-local-web-gui/commit/3fc5b81ce3a3ae005ed74c1ec55a963ea75fee17)

fileserver.go: Added Print
* added Print with server address to CMD/Terminal
(https://github.com/NineNineFive/go-local-web-gui/commit/10edf12588e6f6ccf6ae78c436415037b1f673f1)

go.work: added
* added relative paths to dependencies
(https://github.com/NineNineFive/go-local-web-gui/commit/8d34a9bb4e06fef06bf80799b11f7adc2748f6cc)

go.mod: Changed
* changed from local package name to github location (so updates can be made from github, replace module name if this is not of your wish)
(https://github.com/NineNineFive/go-local-web-gui/commit/cde71ddaaf65bbc4e082c2fcaa8a32cfcd78f429)

go.mod: Changed
* removed forced go version
(https://github.com/NineNineFive/go-local-web-gui/commit/d875ea923aa9aa2f269b4bd2f8b5e7d432b2913a)

launcher.go: Modified
* removed waitgroup from windows chrome launcher
* bidirectional open/close of application is complete
(https://github.com/NineNineFive/go-local-web-gui/commit/2f4cf54123650fe7ac0262c1e11687f5cda0f207)

windows.go: go-cmd removed
* this file is removed together with go-cmd
(https://github.com/NineNineFive/go-local-web-gui/commit/7ba9f3224f6da263d46a55f1ce4c00f13712b8b6)